### PR TITLE
DEV: Set required value of normalize_emails in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # discourse-anonymous-moderators
 
 Allows moderators to have a second account for performing actions anonymously. Other staff members can see the real identity of the account.
+
+**Note:** This feature relies on plus addressing for the child account e-mails, and requires `SiteSetting.normalize_emails` to be turned off.

--- a/spec/lib/manager_spec.rb
+++ b/spec/lib/manager_spec.rb
@@ -28,7 +28,10 @@ describe DiscourseAnonymousModerators::Manager do
     )
   end
 
-  before { SiteSetting.anonymous_moderators_enabled = true }
+  before do
+    SiteSetting.anonymous_moderators_enabled = true
+    SiteSetting.normalize_emails = false
+  end
 
   describe "switching to existing anonymous account" do
     it "returns nil when disabled" do

--- a/spec/requests/switch_controller_spec.rb
+++ b/spec/requests/switch_controller_spec.rb
@@ -3,7 +3,10 @@
 require "rails_helper"
 
 RSpec.describe DiscourseAnonymousModerators::SwitchController do
-  before { SiteSetting.anonymous_moderators_enabled = true }
+  before do
+    SiteSetting.anonymous_moderators_enabled = true
+    SiteSetting.normalize_emails = false
+  end
 
   let(:user) { Fabricate(:user, moderator: true) }
 


### PR DESCRIPTION
### What is this change?

This plugin relies on plus addressing for the e-mail of the anonymous child account, and thus requires `SiteSetting.normalize_emails` to be disabled.

We just changed the default to enabled in core, causing the tests to fail.

This change sets disables it in the plugin's tests again, and adds a note to the README about the requirement.