### PR TITLE
DEV: Add plugin admin title

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,5 +1,7 @@
 en:
   js:
+    discourse_anonymous_moderators:
+      title: "Anonymous moderators"
     anonymous_moderators:
       switch_to_anon: Switch to anonymous moderator account
       switch_to_master: Switch to main account


### PR DESCRIPTION
### What is this change?

This adds a plugin title for the admin sidebar to use.

**Before:**

<img width="250" alt="Screenshot 2025-01-23 at 11 19 41 AM" src="https://github.com/user-attachments/assets/7eac8098-1f25-4d0d-9241-7ccabcfa2867" />

**After:**

<img width="248" alt="Screenshot 2025-01-23 at 11 19 21 AM" src="https://github.com/user-attachments/assets/add28e52-0434-4609-9c1f-fe71dc62f366" />