### PR TITLE
DEV: Remove the legacy widget code

### DIFF
--- a/spec/system/anonymous_user_spec.rb
+++ b/spec/system/anonymous_user_spec.rb
@@ -20,27 +20,21 @@ RSpec.describe "Anonymous Moderator Parent Username", type: :system do
   let!(:post2) { Fabricate(:post, topic: topic, user: user1) }
   let!(:post3) { Fabricate(:post, topic: topic, user: user2) }
 
-  %w[enabled disabled].each do |value|
-    before { SiteSetting.glimmer_post_stream_mode = value }
+  context "for staff" do
+    before do
+      SiteSetting.anonymous_moderators_enabled = true
+      sign_in(moderator)
+    end
 
-    context "when glimmer_post_stream_mode=#{value}" do
-      context "for staff" do
-        before do
-          SiteSetting.anonymous_moderators_enabled = true
-          sign_in(moderator)
-        end
+    it "includes the parent username indicator in the poster name" do
+      visit "/t/#{topic.slug}/#{topic.id}"
 
-        it "includes the parent username indicator in the poster name" do
-          visit "/t/#{topic.slug}/#{topic.id}"
+      expect(page).to have_css("span.poster-parent-username > a.anon-identity")
 
-          expect(page).to have_css("span.poster-parent-username > a.anon-identity")
+      parent_username_indicator = page.find("span.poster-parent-username > a.anon-identity")
 
-          parent_username_indicator = page.find("span.poster-parent-username > a.anon-identity")
-
-          expect(parent_username_indicator["data-user-card"]).to eq(user2.username)
-          expect(parent_username_indicator.text).to have_text(user2.username)
-        end
-      end
+      expect(parent_username_indicator["data-user-card"]).to eq(user2.username)
+      expect(parent_username_indicator.text).to have_text(user2.username)
     end
   end
 end


### PR DESCRIPTION
Remove usages of `glimmer_post_stream_mode` in tests across various files, including acceptance and system-level specs, where it was used to toggle testing behavior. This reduces test complexity and ensures coverage without dependency on this feature flag, which is being phased out.